### PR TITLE
Add encoding information to BillingInformation XML

### DIFF
--- a/app/code/community/Paybox/Epayment/Model/Paybox.php
+++ b/app/code/community/Paybox/Epayment/Model/Paybox.php
@@ -535,7 +535,7 @@ class Paybox_Epayment_Model_Paybox
 		if(empty($tilte))$title = "Mr";
 
 
-        $simpleXMLElement = new SimpleXMLElement("<Billing/>");
+        $simpleXMLElement = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><Billing/>');
         // $billingXML = $simpleXMLElement->addChild('Billing');
         $addressXML = $simpleXMLElement->addChild('Address');
         $addressXML->addChild('FirstName',$firstName);

--- a/app/code/community/Paybox/Epayment/Model/Paybox.php
+++ b/app/code/community/Paybox/Epayment/Model/Paybox.php
@@ -488,7 +488,7 @@ class Paybox_Epayment_Model_Paybox
             $values['PBX_REPONDRE_A'] .= $s;
         }
            $values['PBX_SHOPPINGCART'] = trim(substr($this->getShoppingCartInformation($order),38));
-           $values['PBX_BILLING'] = trim(substr($this->getBillingInformation($order),21));
+           $values['PBX_BILLING'] = trim(substr($this->getBillingInformation($order),38));
 																				 																			   
         // PBX Version
         $values['PBX_VERSION'] = 'Magento_' . Mage::getVersion() . '-' . 'paybox' . '_' . Mage::getConfig()->getModuleConfig("Paybox_Epayment")->version;


### PR DESCRIPTION
`SimpleXMLElement::asXML` automaticaly encode special chars like `°` if no encoding is specified in header : hmac validation fail when billingInformation contains such a char.


